### PR TITLE
test: add integration tests for API endpoints

### DIFF
--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -101,3 +101,5 @@ namespace Api
         }
     }
 }
+// Make Program class accessible for testing
+public partial class Program { }

--- a/Application/Common/Mappings/CategoryProfile.cs
+++ b/Application/Common/Mappings/CategoryProfile.cs
@@ -1,7 +1,7 @@
 ﻿using Application.DTOs;
 using Domain.Entities;
 
-namespace Application.Mappings;
+namespace Application.Common.Mappings;
 
 /// <summary>
 /// AutoMapper profile for Category entity mappings

--- a/Application/Common/Mappings/RecipeProfile.cs
+++ b/Application/Common/Mappings/RecipeProfile.cs
@@ -1,7 +1,7 @@
 ﻿using Application.DTOs;
 using Domain.Entities;
 
-namespace Application.Mappings;
+namespace Application.Common.Mappings;
 
 /// <summary>
 /// AutoMapper profile for Recipe entity mappings

--- a/Application/Common/Mappings/UserProfile.cs
+++ b/Application/Common/Mappings/UserProfile.cs
@@ -1,7 +1,7 @@
 ﻿using Application.DTOs;
 using Domain.Entities;
 
-namespace Application.Mappings;
+namespace Application.Common.Mappings;
 
 /// <summary>
 /// AutoMapper profile for User entity mappings

--- a/Tests/ApplicationTests/Mappings/MappingProfileTests.cs
+++ b/Tests/ApplicationTests/Mappings/MappingProfileTests.cs
@@ -1,6 +1,5 @@
 ﻿using Application.Common.Mappings;
 using Application.DTOs;
-using Application.Mappings;
 using AutoMapper;
 using Domain.Entities;
 using FluentAssertions;

--- a/Tests/InfrastructureTests/ApiIntegrationTests.cs
+++ b/Tests/InfrastructureTests/ApiIntegrationTests.cs
@@ -1,0 +1,146 @@
+﻿using Application.DTOs;
+using FluentAssertions;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace Tests.InfrastructureTests;
+
+/// <summary>
+/// Integration tests for Savory API endpoints
+/// </summary>
+public class ApiIntegrationTests : IntegrationTestBase
+{
+    public ApiIntegrationTests(CustomWebApplicationFactory factory) : base(factory)
+    {
+    }
+
+    [Fact]
+    public async Task AuthFlow_RegisterLoginAndAccessProtectedEndpoint_ShouldSucceed()
+    {
+        // Arrange
+        var userName = "testuser";
+        var email = "test@example.com";
+        var password = "Test123";
+
+        // Act - Register
+        var registerResponse = await RegisterUserAsync(userName, email, password);
+
+        // Assert - Registration successful
+        registerResponse.Should().NotBeNull();
+        registerResponse.Token.Should().NotBeNullOrEmpty();
+        registerResponse.User.Should().NotBeNull();
+        registerResponse.User.UserName.Should().Be(userName);
+        registerResponse.User.Email.Should().Be(email);
+
+        // Act - Login
+        var loginResponse = await LoginUserAsync(email, password);
+
+        // Assert - Login successful
+        loginResponse.Should().NotBeNull();
+        loginResponse.Token.Should().NotBeNullOrEmpty();
+        loginResponse.User.UserName.Should().Be(userName);
+
+        // Act - Access protected endpoint
+        SetAuthorizationHeader(loginResponse.Token);
+        var recipesResponse = await Client.GetAsync("/api/recipe");
+
+        // Assert - Can access protected endpoint
+        recipesResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task RecipeCRUD_CreateAndRetrieveRecipe_ShouldSucceed()
+    {
+        // Arrange - Register and login
+        var authResponse = await RegisterUserAsync("recipeuser", "recipe@example.com", "Recipe123");
+        SetAuthorizationHeader(authResponse.Token);
+
+        // Get categories to use valid category ID
+        var categoriesResponse = await Client.GetAsync("/api/category");
+        var categories = await categoriesResponse.Content.ReadFromJsonAsync<List<CategoryWithCountDto>>();
+        var categoryId = categories!.First().Id;
+
+        // Get ingredients to use valid ingredient ID
+        var ingredientsResponse = await Client.GetAsync("/api/ingredient");
+        var ingredients = await ingredientsResponse.Content.ReadFromJsonAsync<List<IngredientDto>>();
+        var ingredientId = ingredients!.First().Id;
+
+        // Act - Create recipe
+        var createRecipeRequest = new
+        {
+            title = "Test Recipe",
+            description = "Test Description",
+            instructions = "Test Instructions",
+            prepTime = 10,
+            cookTime = 20,
+            servings = 4,
+            categoryId,
+            ingredients = new[]
+            {
+                new { ingredientId, quantity = 100 }
+            }
+        };
+
+        var createResponse = await Client.PostAsJsonAsync("/api/recipe", createRecipeRequest);
+
+        // Assert - Recipe created
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var createdRecipe = await createResponse.Content.ReadFromJsonAsync<RecipeDto>();
+        createdRecipe.Should().NotBeNull();
+        createdRecipe!.Title.Should().Be("Test Recipe");
+        createdRecipe.Ingredients.Should().HaveCount(1);
+
+        // Act - Get recipe by ID
+        var getResponse = await Client.GetAsync($"/api/recipe/{createdRecipe.Id}");
+
+        // Assert - Recipe retrieved
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var retrievedRecipe = await getResponse.Content.ReadFromJsonAsync<RecipeDto>();
+        retrievedRecipe.Should().NotBeNull();
+        retrievedRecipe!.Title.Should().Be("Test Recipe");
+        retrievedRecipe.Description.Should().Be("Test Description");
+    }
+
+    [Fact]
+    public async Task RecipeAuthorization_UserCannotAccessOtherUsersRecipes_ShouldReturnNotFound()
+    {
+        // Arrange - User A creates a recipe
+        var userA = await RegisterUserAsync("usera", "usera@example.com", "UserA123");
+        SetAuthorizationHeader(userA.Token);
+
+        var categoriesResponse = await Client.GetAsync("/api/category");
+        var categories = await categoriesResponse.Content.ReadFromJsonAsync<List<CategoryWithCountDto>>();
+        var categoryId = categories!.First().Id;
+
+        var ingredientsResponse = await Client.GetAsync("/api/ingredient");
+        var ingredients = await ingredientsResponse.Content.ReadFromJsonAsync<List<IngredientDto>>();
+        var ingredientId = ingredients!.First().Id;
+
+        var createRecipeRequest = new
+        {
+            title = "User A Recipe",
+            description = "Private recipe",
+            instructions = "Secret instructions",
+            prepTime = 5,
+            cookTime = 10,
+            servings = 2,
+            categoryId,
+            ingredients = new[]
+            {
+                new { ingredientId, quantity = 50 }
+            }
+        };
+
+        var createResponse = await Client.PostAsJsonAsync("/api/recipe", createRecipeRequest);
+        var userARecipe = await createResponse.Content.ReadFromJsonAsync<RecipeDto>();
+
+        // Act - User B tries to access User A's recipe
+        var userB = await RegisterUserAsync("userb", "userb@example.com", "UserB123");
+        SetAuthorizationHeader(userB.Token);
+
+        var getResponse = await Client.GetAsync($"/api/recipe/{userARecipe!.Id}");
+
+        // Assert - User B cannot access User A's recipe
+        getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/Tests/InfrastructureTests/CustomWebApplicationFactory.cs
+++ b/Tests/InfrastructureTests/CustomWebApplicationFactory.cs
@@ -1,12 +1,9 @@
 ﻿using Infrastructure.Data;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.IdentityModel.Tokens;
-using System.Text;
 
 namespace Tests.InfrastructureTests;
 
@@ -17,27 +14,26 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
 {
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
-        builder.ConfigureAppConfiguration((context, config) =>
-        {
-            // Add test JWT configuration
-            config.AddInMemoryCollection(new Dictionary<string, string?>
+        // CRITICAL: Set configuration FIRST, before anything else
+        builder.UseConfiguration(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Jwt:Key"] = "ThisIsATestSecretKeyForJWTTokensMinimum32Characters!",
+                ["Jwt:Key"] = "ThisIsATestSecretKeyForJWTTokensMinimum32CharactersLong!!!",
                 ["Jwt:Issuer"] = "SavoryAPI",
                 ["Jwt:Audience"] = "SavoryAPI",
                 ["Jwt:ExpiresInMinutes"] = "60"
-            });
-        });
+            })
+            .Build());
 
         builder.ConfigureServices(services =>
         {
             // Remove existing DbContext
-            var dbContextDescriptor = services.SingleOrDefault(
+            var descriptor = services.SingleOrDefault(
                 d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
 
-            if (dbContextDescriptor != null)
+            if (descriptor != null)
             {
-                services.Remove(dbContextDescriptor);
+                services.Remove(descriptor);
             }
 
             // Add in-memory database
@@ -46,36 +42,10 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
                 options.UseInMemoryDatabase("TestDatabase");
             });
 
-            // Reconfigure JWT authentication to use test settings
-            var jwtDescriptor = services.SingleOrDefault(
-                d => d.ServiceType.Name == "IConfigureOptions`1" &&
-                     d.ImplementationType?.Name.Contains("JwtBearer") == true);
-
-            if (jwtDescriptor != null)
-            {
-                services.Remove(jwtDescriptor);
-            }
-
-            // Re-add JWT authentication with test key
-            services.Configure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
-            {
-                options.TokenValidationParameters = new TokenValidationParameters
-                {
-                    ValidateIssuer = true,
-                    ValidateAudience = true,
-                    ValidateLifetime = true,
-                    ValidateIssuerSigningKey = true,
-                    ValidIssuer = "SavoryAPI",
-                    ValidAudience = "SavoryAPI",
-                    IssuerSigningKey = new SymmetricSecurityKey(
-                        Encoding.UTF8.GetBytes("ThisIsATestSecretKeyForJWTTokensMinimum32Characters!")),
-                    ClockSkew = TimeSpan.Zero
-                };
-            });
-
-            // Build service provider and ensure database is created
+            // Build service provider
             var sp = services.BuildServiceProvider();
 
+            // Ensure database is created
             using var scope = sp.CreateScope();
             var scopedServices = scope.ServiceProvider;
             var db = scopedServices.GetRequiredService<ApplicationDbContext>();

--- a/Tests/InfrastructureTests/CustomWebApplicationFactory.cs
+++ b/Tests/InfrastructureTests/CustomWebApplicationFactory.cs
@@ -1,0 +1,44 @@
+﻿using Api;
+using Infrastructure.Data;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests.InfrastructureTests;
+
+/// <summary>
+/// Custom WebApplicationFactory for integration testing with in-memory database
+/// </summary>
+public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            // Remove existing DbContext
+            var descriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+
+            if (descriptor != null)
+            {
+                services.Remove(descriptor);
+            }
+
+            // Add in-memory database
+            services.AddDbContext<ApplicationDbContext>(options =>
+            {
+                options.UseInMemoryDatabase("TestDatabase");
+            });
+
+            // Build service provider
+            var sp = services.BuildServiceProvider();
+
+            // Ensure database is created
+            using var scope = sp.CreateScope();
+            var scopedServices = scope.ServiceProvider;
+            var db = scopedServices.GetRequiredService<ApplicationDbContext>();
+            db.Database.EnsureCreated();
+        });
+    }
+}

--- a/Tests/InfrastructureTests/CustomWebApplicationFactory.cs
+++ b/Tests/InfrastructureTests/CustomWebApplicationFactory.cs
@@ -1,9 +1,12 @@
-﻿using Api;
-using Infrastructure.Data;
+﻿using Infrastructure.Data;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 
 namespace Tests.InfrastructureTests;
 
@@ -14,15 +17,27 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
 {
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
+        builder.ConfigureAppConfiguration((context, config) =>
+        {
+            // Add test JWT configuration
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Key"] = "ThisIsATestSecretKeyForJWTTokensMinimum32Characters!",
+                ["Jwt:Issuer"] = "SavoryAPI",
+                ["Jwt:Audience"] = "SavoryAPI",
+                ["Jwt:ExpiresInMinutes"] = "60"
+            });
+        });
+
         builder.ConfigureServices(services =>
         {
             // Remove existing DbContext
-            var descriptor = services.SingleOrDefault(
+            var dbContextDescriptor = services.SingleOrDefault(
                 d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
 
-            if (descriptor != null)
+            if (dbContextDescriptor != null)
             {
-                services.Remove(descriptor);
+                services.Remove(dbContextDescriptor);
             }
 
             // Add in-memory database
@@ -31,10 +46,36 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
                 options.UseInMemoryDatabase("TestDatabase");
             });
 
-            // Build service provider
+            // Reconfigure JWT authentication to use test settings
+            var jwtDescriptor = services.SingleOrDefault(
+                d => d.ServiceType.Name == "IConfigureOptions`1" &&
+                     d.ImplementationType?.Name.Contains("JwtBearer") == true);
+
+            if (jwtDescriptor != null)
+            {
+                services.Remove(jwtDescriptor);
+            }
+
+            // Re-add JWT authentication with test key
+            services.Configure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
+            {
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true,
+                    ValidIssuer = "SavoryAPI",
+                    ValidAudience = "SavoryAPI",
+                    IssuerSigningKey = new SymmetricSecurityKey(
+                        Encoding.UTF8.GetBytes("ThisIsATestSecretKeyForJWTTokensMinimum32Characters!")),
+                    ClockSkew = TimeSpan.Zero
+                };
+            });
+
+            // Build service provider and ensure database is created
             var sp = services.BuildServiceProvider();
 
-            // Ensure database is created
             using var scope = sp.CreateScope();
             var scopedServices = scope.ServiceProvider;
             var db = scopedServices.GetRequiredService<ApplicationDbContext>();

--- a/Tests/InfrastructureTests/IntegrationTestBase.cs
+++ b/Tests/InfrastructureTests/IntegrationTestBase.cs
@@ -1,0 +1,71 @@
+﻿using Application.DTOs;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace Tests.InfrastructureTests;
+
+/// <summary>
+/// Base class for integration tests with helper methods
+/// </summary>
+public class IntegrationTestBase : IClassFixture<CustomWebApplicationFactory>
+{
+    protected readonly HttpClient Client;
+
+    protected IntegrationTestBase(CustomWebApplicationFactory factory)
+    {
+        Client = factory.CreateClient();
+    }
+
+    /// <summary>
+    /// Registers a new user and returns authentication response
+    /// </summary>
+    protected async Task<AuthResponseDto> RegisterUserAsync(string userName, string email, string password)
+    {
+        var registerRequest = new
+        {
+            userName,
+            email,
+            password
+        };
+
+        var response = await Client.PostAsJsonAsync("/api/auth/register", registerRequest);
+        response.EnsureSuccessStatusCode();
+
+        var authResponse = await response.Content.ReadFromJsonAsync<AuthResponseDto>();
+        return authResponse!;
+    }
+
+    /// <summary>
+    /// Logs in a user and returns authentication response
+    /// </summary>
+    protected async Task<AuthResponseDto> LoginUserAsync(string email, string password)
+    {
+        var loginRequest = new
+        {
+            email,
+            password
+        };
+
+        var response = await Client.PostAsJsonAsync("/api/auth/login", loginRequest);
+        response.EnsureSuccessStatusCode();
+
+        var authResponse = await response.Content.ReadFromJsonAsync<AuthResponseDto>();
+        return authResponse!;
+    }
+
+    /// <summary>
+    /// Sets authorization header with JWT token
+    /// </summary>
+    protected void SetAuthorizationHeader(string token)
+    {
+        Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+    }
+
+    /// <summary>
+    /// Clears authorization header
+    /// </summary>
+    protected void ClearAuthorizationHeader()
+    {
+        Client.DefaultRequestHeaders.Authorization = null;
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.22" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.22" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.5.3" />
@@ -27,12 +29,13 @@
     <Folder Include="ApplicationTests\Queries\" />
     <Folder Include="ApplicationTests\Validators\" />
     <Folder Include="DomainTests\" />
-    <Folder Include="InfrastructureTests\" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Api\Api.csproj" />
     <ProjectReference Include="..\Application\Application.csproj" />
     <ProjectReference Include="..\Domain\Domain.csproj" />
+    <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Set up WebApplicationFactory with in-memory database
- Created IntegrationTestBase with helper methods for auth
- Added 3 integration tests:
  1. Auth flow (register, login, access protected endpoint)
  2. Recipe CRUD (create and retrieve recipe)
  3. Authorization (user cannot access other user's recipes)
- All tests use in-memory database (no external dependencies)
- Tests verify authentication, authorization, and CRUD operations

Meets VG requirement for 3+ integration tests.

Closes #20