### PR TITLE
test: add unit tests for command and query handlers

### DIFF
--- a/Tests/ApplicationTests/Commands/CreateRecipeCommandHandlerTests.cs
+++ b/Tests/ApplicationTests/Commands/CreateRecipeCommandHandlerTests.cs
@@ -1,0 +1,107 @@
+﻿using Application.Interfaces;
+using Application.Recipes.Commands.CreateRecipe;
+using AutoMapper;
+using Domain.Entities;
+using FluentAssertions;
+using Moq;
+
+namespace Tests.ApplicationTests.Commands;
+
+public class CreateRecipeCommandHandlerTests
+{
+    private readonly Mock<IRecipeRepository> _mockRecipeRepository;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ICurrentUserService> _mockCurrentUserService;
+    private readonly CreateRecipeCommandHandler _handler;
+
+    public CreateRecipeCommandHandlerTests()
+    {
+        _mockRecipeRepository = new Mock<IRecipeRepository>();
+        _mockMapper = new Mock<IMapper>();
+        _mockCurrentUserService = new Mock<ICurrentUserService>();
+
+        _handler = new CreateRecipeCommandHandler(
+            _mockRecipeRepository.Object,
+            _mockMapper.Object,
+            _mockCurrentUserService.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ShouldCreateRecipeAndReturnSuccess()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var recipeId = Guid.NewGuid();
+
+        _mockCurrentUserService.Setup(x => x.GetUserId()).Returns(userId);
+
+        var command = new CreateRecipeCommand
+        {
+            Title = "Test Recipe",
+            Description = "Test Description",
+            Instructions = "Test Instructions",
+            PrepTime = 10,
+            CookTime = 20,
+            Servings = 4,
+            CategoryId = Guid.NewGuid(),
+            Ingredients = new List<Application.DTOs.RecipeIngredientCreateDto>
+            {
+                new() { IngredientId = Guid.NewGuid(), Quantity = 100 }
+            }
+        };
+
+        var recipe = new Recipe
+        {
+            Id = recipeId,
+            UserId = userId,
+            Title = command.Title
+        };
+
+        _mockRecipeRepository.Setup(x => x.GetRecipeWithDetailsAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(recipe);
+
+        _mockMapper.Setup(x => x.Map<Application.DTOs.RecipeDto>(It.IsAny<Recipe>()))
+            .Returns(new Application.DTOs.RecipeDto { Id = recipeId, Title = command.Title });
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+        result.Data.Should().NotBeNull();
+        result.Data!.Title.Should().Be(command.Title);
+
+        _mockRecipeRepository.Verify(x => x.AddAsync(It.IsAny<Recipe>()), Times.Once);
+        _mockRecipeRepository.Verify(x => x.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UserNotAuthenticated_ShouldReturnFailure()
+    {
+        // Arrange
+        _mockCurrentUserService.Setup(x => x.GetUserId()).Returns((Guid?)null);
+
+        var command = new CreateRecipeCommand
+        {
+            Title = "Test Recipe",
+            Description = "Test Description",
+            Instructions = "Test Instructions",
+            PrepTime = 10,
+            CookTime = 20,
+            Servings = 4,
+            CategoryId = Guid.NewGuid(),
+            Ingredients = new List<Application.DTOs.RecipeIngredientCreateDto>()
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Be("User not authenticated");
+
+        _mockRecipeRepository.Verify(x => x.AddAsync(It.IsAny<Recipe>()), Times.Never);
+    }
+}

--- a/Tests/ApplicationTests/Commands/DeleteRecipeCommandHandlerTests.cs
+++ b/Tests/ApplicationTests/Commands/DeleteRecipeCommandHandlerTests.cs
@@ -1,0 +1,81 @@
+﻿using Application.Interfaces;
+using Application.Recipes.Commands.DeleteRecipe;
+using Domain.Entities;
+using FluentAssertions;
+using Moq;
+
+namespace Tests.ApplicationTests.Commands;
+
+public class DeleteRecipeCommandHandlerTests
+{
+    private readonly Mock<IRecipeRepository> _mockRecipeRepository;
+    private readonly Mock<ICurrentUserService> _mockCurrentUserService;
+    private readonly DeleteRecipeCommandHandler _handler;
+
+    public DeleteRecipeCommandHandlerTests()
+    {
+        _mockRecipeRepository = new Mock<IRecipeRepository>();
+        _mockCurrentUserService = new Mock<ICurrentUserService>();
+
+        _handler = new DeleteRecipeCommandHandler(
+            _mockRecipeRepository.Object,
+            _mockCurrentUserService.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ShouldDeleteRecipeAndReturnSuccess()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var recipeId = Guid.NewGuid();
+
+        _mockCurrentUserService.Setup(x => x.GetUserId()).Returns(userId);
+
+        var existingRecipe = new Recipe
+        {
+            Id = recipeId,
+            UserId = userId,
+            Title = "Recipe to Delete"
+        };
+
+        _mockRecipeRepository.Setup(x => x.GetByIdAsync(recipeId))
+            .ReturnsAsync(existingRecipe);
+
+        var command = new DeleteRecipeCommand { Id = recipeId };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+
+        _mockRecipeRepository.Verify(x => x.DeleteAsync(recipeId), Times.Once);
+        _mockRecipeRepository.Verify(x => x.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_RecipeNotFound_ShouldReturnFailure()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var recipeId = Guid.NewGuid();
+
+        _mockCurrentUserService.Setup(x => x.GetUserId()).Returns(userId);
+
+        _mockRecipeRepository.Setup(x => x.GetByIdAsync(recipeId))
+            .ReturnsAsync((Recipe?)null);
+
+        var command = new DeleteRecipeCommand { Id = recipeId };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("not found");
+
+        _mockRecipeRepository.Verify(x => x.DeleteAsync(It.IsAny<Guid>()), Times.Never);
+    }
+}

--- a/Tests/ApplicationTests/Commands/UpdateRecipeCommandHandlerTests.cs
+++ b/Tests/ApplicationTests/Commands/UpdateRecipeCommandHandlerTests.cs
@@ -1,0 +1,119 @@
+﻿using Application.Interfaces;
+using Application.Recipes.Commands.UpdateRecipe;
+using AutoMapper;
+using Domain.Entities;
+using FluentAssertions;
+using Moq;
+
+namespace Tests.ApplicationTests.Commands;
+
+public class UpdateRecipeCommandHandlerTests
+{
+    private readonly Mock<IRecipeRepository> _mockRecipeRepository;
+    private readonly Mock<ICurrentUserService> _mockCurrentUserService;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly UpdateRecipeCommandHandler _handler;
+
+    public UpdateRecipeCommandHandlerTests()
+    {
+        _mockRecipeRepository = new Mock<IRecipeRepository>();
+        _mockCurrentUserService = new Mock<ICurrentUserService>();
+        _mockMapper = new Mock<IMapper>();
+
+        _handler = new UpdateRecipeCommandHandler(
+            _mockRecipeRepository.Object,
+            _mockMapper.Object,
+            _mockCurrentUserService.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ShouldUpdateRecipeAndReturnSuccess()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var recipeId = Guid.NewGuid();
+
+        _mockCurrentUserService.Setup(x => x.GetUserId()).Returns(userId);
+
+        var existingRecipe = new Recipe
+        {
+            Id = recipeId,
+            UserId = userId,
+            Title = "Old Title",
+            RecipeIngredients = new List<RecipeIngredient>() // ← Already initialized
+        };
+
+        // Use GetRecipeWithDetailsAsync instead of GetByIdAsync
+        _mockRecipeRepository.Setup(x => x.GetRecipeWithDetailsAsync(recipeId))
+            .ReturnsAsync(existingRecipe);
+
+        var command = new UpdateRecipeCommand
+        {
+            Id = recipeId,
+            Title = "Updated Title",
+            Description = "Updated Description",
+            Instructions = "Updated Instructions",
+            PrepTime = 15,
+            CookTime = 25,
+            Servings = 6,
+            CategoryId = Guid.NewGuid(),
+            Ingredients = new List<Application.DTOs.RecipeIngredientCreateDto>()
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+        existingRecipe.Title.Should().Be("Updated Title");
+
+        _mockRecipeRepository.Verify(x => x.UpdateAsync(existingRecipe), Times.Once);
+        _mockRecipeRepository.Verify(x => x.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UserNotOwner_ShouldReturnFailure()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        var recipeId = Guid.NewGuid();
+
+        _mockCurrentUserService.Setup(x => x.GetUserId()).Returns(userId);
+
+        var existingRecipe = new Recipe
+        {
+            Id = recipeId,
+            UserId = otherUserId, // Different user!
+            Title = "Old Title",
+            RecipeIngredients = new List<RecipeIngredient>() // ← Already initialized
+        };
+
+        _mockRecipeRepository.Setup(x => x.GetRecipeWithDetailsAsync(recipeId))
+            .ReturnsAsync(existingRecipe);
+
+        var command = new UpdateRecipeCommand
+        {
+            Id = recipeId,
+            Title = "Updated Title",
+            Description = "Updated Description",
+            Instructions = "Updated Instructions",
+            PrepTime = 15,
+            CookTime = 25,
+            Servings = 6,
+            CategoryId = Guid.NewGuid(),
+            Ingredients = new List<Application.DTOs.RecipeIngredientCreateDto>()
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("only edit your own");
+
+        _mockRecipeRepository.Verify(x => x.UpdateAsync(It.IsAny<Recipe>()), Times.Never);
+    }
+}

--- a/Tests/ApplicationTests/Queries/GetRecipeByIdQueryHandlerTests.cs
+++ b/Tests/ApplicationTests/Queries/GetRecipeByIdQueryHandlerTests.cs
@@ -1,0 +1,93 @@
+﻿using Application.Interfaces;
+using Application.Recipes.Queries.GetRecipeById;
+using AutoMapper;
+using Domain.Entities;
+using FluentAssertions;
+using Moq;
+
+namespace Tests.ApplicationTests.Queries;
+
+public class GetRecipeByIdQueryHandlerTests
+{
+    private readonly Mock<IRecipeRepository> _mockRecipeRepository;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ICurrentUserService> _mockCurrentUserService;
+    private readonly GetRecipeByIdQueryHandler _handler;
+
+    public GetRecipeByIdQueryHandlerTests()
+    {
+        _mockRecipeRepository = new Mock<IRecipeRepository>();
+        _mockMapper = new Mock<IMapper>();
+        _mockCurrentUserService = new Mock<ICurrentUserService>();
+
+        _handler = new GetRecipeByIdQueryHandler(
+            _mockRecipeRepository.Object,
+            _mockMapper.Object,
+            _mockCurrentUserService.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ShouldReturnRecipe()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var recipeId = Guid.NewGuid();
+
+        _mockCurrentUserService.Setup(x => x.GetUserId()).Returns(userId);
+
+        var recipe = new Recipe
+        {
+            Id = recipeId,
+            UserId = userId,
+            Title = "Test Recipe"
+        };
+
+        _mockRecipeRepository.Setup(x => x.GetRecipeWithDetailsAsync(recipeId))
+            .ReturnsAsync(recipe);
+
+        _mockMapper.Setup(x => x.Map<Application.DTOs.RecipeDto>(recipe))
+            .Returns(new Application.DTOs.RecipeDto { Id = recipeId, Title = "Test Recipe" });
+
+        var query = new GetRecipeByIdQuery { Id = recipeId };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+        result.Data.Should().NotBeNull();
+        result.Data!.Title.Should().Be("Test Recipe");
+    }
+
+    [Fact]
+    public async Task Handle_UserNotOwner_ShouldReturnFailure()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        var recipeId = Guid.NewGuid();
+
+        _mockCurrentUserService.Setup(x => x.GetUserId()).Returns(userId);
+
+        var recipe = new Recipe
+        {
+            Id = recipeId,
+            UserId = otherUserId, // Different user!
+            Title = "Private Recipe"
+        };
+
+        _mockRecipeRepository.Setup(x => x.GetRecipeWithDetailsAsync(recipeId))
+            .ReturnsAsync(recipe);
+
+        var query = new GetRecipeByIdQuery { Id = recipeId };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("only view your own");
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -10,6 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="ApplicationTests\Validators\**" />
+    <EmbeddedResource Remove="ApplicationTests\Validators\**" />
+    <None Remove="ApplicationTests\Validators\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.22" />
@@ -22,13 +28,6 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="ApplicationTests\Commands\" />
-    <Folder Include="ApplicationTests\Queries\" />
-    <Folder Include="ApplicationTests\Validators\" />
-    <Folder Include="DomainTests\" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Set up UnitTests project with Moq and FluentAssertions
- Created 8 unit tests for recipe handlers:
  1. CreateRecipeCommandHandler - success case
  2. CreateRecipeCommandHandler - user not authenticated
  3. UpdateRecipeCommandHandler - success case
  4. UpdateRecipeCommandHandler - unauthorized (not owner)
  5. DeleteRecipeCommandHandler - success case
  6. DeleteRecipeCommandHandler - recipe not found
  7. GetRecipeByIdQueryHandler - success case
  8. GetRecipeByIdQueryHandler - unauthorized (not owner)
- All tests use mocked dependencies (repositories, services, mapper)
- Tests verify business logic, authorization, and error handling
- All tests pass

Meets G requirement for 8+ unit tests.
Combined with 3 integration tests, meets VG requirements.

Closes #19